### PR TITLE
Fix #63

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -178,3 +178,12 @@ struct UnsupportedOperationException : public MetroException {
         MetroException(message)
     {}
 };
+
+/**
+ * ANSIException should be thrown when a command requiring ANSI to be enabled is issued, but fails
+ */
+struct ANSIException : public MetroException {
+    explicit ANSIException():
+            MetroException("This terminal is incompatible with special character features: These features have been disabled.")
+    {}
+};

--- a/include/error.h
+++ b/include/error.h
@@ -184,6 +184,6 @@ struct UnsupportedOperationException : public MetroException {
  */
 struct ANSIException : public MetroException {
     explicit ANSIException():
-            MetroException("This terminal is incompatible with special character features: These features have been disabled.")
+            MetroException("This terminal is incompatible with special character features.")
     {}
 };

--- a/include/helper.h
+++ b/include/helper.h
@@ -179,3 +179,11 @@ void enable_ansi();
  * Does nothing on other OSs.
  */
 void disable_ansi();
+
+/**
+ * Cross-platform environment variable getter
+ *
+ * @param name Name of variable to get
+ * @return The contents of the variable
+ */
+string get_env(string name);

--- a/include/helper.h
+++ b/include/helper.h
@@ -186,4 +186,4 @@ void disable_ansi();
  * @param name Name of variable to get
  * @return The contents of the variable
  */
-string get_env(string name);
+string get_env(const string& name);

--- a/include/helper.h
+++ b/include/helper.h
@@ -181,9 +181,10 @@ void enable_ansi();
 void disable_ansi();
 
 /**
- * Cross-platform environment variable getter
+ * Cross-platform environment variable getter.
  *
  * @param name Name of variable to get
+ * @param buffer Max length of output string
  * @return The contents of the variable
  */
-string get_env(string name);
+string get_env(string name, int buffer);

--- a/include/helper.h
+++ b/include/helper.h
@@ -184,7 +184,6 @@ void disable_ansi();
  * Cross-platform environment variable getter.
  *
  * @param name Name of variable to get
- * @param buffer Max length of output string
  * @return The contents of the variable
  */
-string get_env(string name, int buffer);
+string get_env(string name);

--- a/src/commands/sink.cpp
+++ b/src/commands/sink.cpp
@@ -11,6 +11,11 @@ Command sinkCmd{
 
         // execute
         [](const Arguments& args) {
+            if (!t_ops.progress_enabled) {
+                cout << "Metro will not be sunk so easily!" << endl;
+                cout << "Did you mean \"metro sync\"?" << endl;
+                return;
+            }
 #ifdef _WIN32
             CONSOLE_SCREEN_BUFFER_INFO csbi;
             GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -468,24 +468,25 @@ void disable_ansi() {
 
 string get_env(const string& name) {
 #ifdef _WIN32
-    // Create 50 char long string (Inc. Null-terminator)
+    // Create 50 char long string (inc. null-terminator)
     // Default to empty string if no contents are set.
     char temp[50];
     temp[0] = '\0';
     const int actual = GetEnvironmentVariable(name.c_str(), temp, 50);
     
-    // If return is < 50, the string (w/o Null-terminator) was inputted correctly
+    // If return is < 50, the string was inputted correctly
+    // and actual is the length of the string w/o null-terminator.
     if (actual < 50) return string(temp);
     
     // Should never occur
     assert(actual != 50);
     
-    // Otherwise if > 50, the string length (w/t Null-terminator) is given to create a new string
+    // Otherwise if > 50, the string length (with null-terminator) is given to create a new string
     char *temp1 = new char[actual];
     temp1[0] = '\0';
     const int check = GetEnvironmentVariable(name.c_str(), temp, actual);
     
-    // String must be at least 50 chars (w/o Null-terminator), or the last call should have succeeded
+    // String must be at least 50 chars (w/o null-terminator), or the last call should have succeeded
     assert(check >= 50);
     // String should fit within the new allocated string
     assert(check < actual);

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -468,13 +468,28 @@ void disable_ansi() {
 
 string get_env(string name) {
 #ifdef _WIN32
+    // Create 50 char long string (Inc. Null-terminator)
+    // Default to empty string if no contents are set.
     char temp[50];
     temp[0] = '\0';
     const int actual = GetEnvironmentVariable(name.c_str(), temp, 50);
-    if (actual <= 50) return string(temp);
+    
+    // If return is < 50, the string (w/o Null-terminator) was inputted correctly
+    if (actual < 50) return string(temp);
+    
+    // Should never occur
+    assert(actual != 50);
+    
+    // Otherwise if > 50, the string length (w/t Null-terminator) is given to create a new string
     char *temp1 = new char[actual];
     temp1[0] = '\0';
-    GetEnvironmentVariable(name.c_str(), temp, actual+1);
+    const int check = GetEnvironmentVariable(name.c_str(), temp, actual);
+    
+    // String must be at least 50 chars (w/o Null-terminator), or the last call should have succeeded
+    assert(check >= 50);
+    // String should fit within the new allocated string
+    assert(check < actual);
+    
     string final(temp1);
     delete[] temp1;
     return final;

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -470,7 +470,7 @@ string get_env(string name) {
 #ifdef _WIN32
     char temp[50];
     temp[0] = '\0';
-    const int actual = GetEnvironmentVariable(name.c_str(), temp, 51);
+    const int actual = GetEnvironmentVariable(name.c_str(), temp, 50);
     if (actual <= 50) return string(temp);
     char *temp1 = new char[actual];
     temp1[0] = '\0';

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -466,9 +466,8 @@ void disable_ansi() {
 #endif //_WIN32
 }
 
-string get_env(string name) {
+string get_env(string name, const int BUFFER_S) {
 #ifdef _WIN32
-    const int BUFFER_S = 100;
     char temp[BUFFER_S];
     temp[0] = '\0';
     GetEnvironmentVariable(name.c_str(), temp, BUFFER_S+1);

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -476,6 +476,7 @@ string get_env(string name) {
     temp1[0] = '\0';
     GetEnvironmentVariable(name.c_str(), temp, actual+1);
     string final(temp1);
+    delete[] temp1;
     return final;
 #elif __unix__ || __APPLE__ || __MACH__
     return string(getenv(name.c_str()));

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -466,7 +466,7 @@ void disable_ansi() {
 #endif //_WIN32
 }
 
-string get_env(string name) {
+string get_env(const string& name) {
 #ifdef _WIN32
     // Create 50 char long string (Inc. Null-terminator)
     // Default to empty string if no contents are set.

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -466,12 +466,17 @@ void disable_ansi() {
 #endif //_WIN32
 }
 
-string get_env(string name, const int BUFFER_S) {
+string get_env(string name) {
 #ifdef _WIN32
-    char temp[BUFFER_S];
+    char temp[50];
     temp[0] = '\0';
-    GetEnvironmentVariable(name.c_str(), temp, BUFFER_S+1);
-    return string(temp);
+    const int actual = GetEnvironmentVariable(name.c_str(), temp, 51);
+    if (actual <= 50) return string(temp);
+    char *temp1 = new char[actual];
+    temp1[0] = '\0';
+    GetEnvironmentVariable(name.c_str(), temp, actual+1);
+    string final(temp1);
+    return final;
 #elif __unix__ || __APPLE__ || __MACH__
     return string(getenv(name.c_str()));
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,8 +156,8 @@ int main(int argc, char *argv[]) {
     // Windows terminals don't all work out the box
 #ifdef _WIN32
     // If terminal is xterm, we know colours work normally
-    t_ops.term = get_env("TERM");
-    if (t_ops.term == "") {
+    t_ops.term = get_env("TERM", 20);
+    if (t_ops.term.empty()) {
         // Disable ANSI if it would error normally.
         try {
             enable_ansi();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,18 +167,18 @@ int main(int argc, char *argv[]) {
         } catch (ANSIException &e) {
             t_ops.ansi_enabled = false;
             t_ops.progress_enabled = false;
-            t_ops.colour_change = false;
+            t_ops.ansi_colour_change = false;
         }
     } else if (t_ops.term == "xterm") {
         // xterm is known to work with ANSI colour-codes
         t_ops.ansi_enabled = false;
         t_ops.progress_enabled = false;
-        t_ops.colour_change = true;
+        t_ops.ansi_colour_change = true;
     } else {
         // If term is unknown, assume the worst
         t_ops.ansi_enabled = false;
         t_ops.progress_enabled = false;
-        t_ops.colour_change = false;
+        t_ops.ansi_colour_change = false;
     }
 #endif //_WIN32
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,7 @@ int main(int argc, char *argv[]) {
     // Windows terminals don't all work out the box
 #ifdef _WIN32
     // If terminal is xterm, we know colours work normally
-    t_ops.term = get_env("TERM", 20);
+    t_ops.term = get_env("TERM");
     if (t_ops.term.empty()) {
         // Disable ANSI if it would error normally.
         try {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,6 +153,35 @@ int main(int argc, char *argv[]) {
 
     git_libgit2_init();
 
+    // Windows terminals don't all work out the box
+#ifdef _WIN32
+    // If terminal is xterm, we know colours work normally
+    t_ops.term = get_env("TERM");
+    if (t_ops.term == "") {
+        // Disable ANSI if it would error normally.
+        try {
+            enable_ansi();
+            disable_ansi();
+
+            // If success, assume correct Windows terminal with all features
+        } catch (ANSIException &e) {
+            t_ops.ansi_enabled = false;
+            t_ops.progress_enabled = false;
+            t_ops.colour_change = false;
+        }
+    } else if (t_ops.term == "xterm") {
+        // xterm is known to work with ANSI colour-codes
+        t_ops.ansi_enabled = false;
+        t_ops.progress_enabled = false;
+        t_ops.colour_change = true;
+    } else {
+        // If term is unknown, assume the worst
+        t_ops.ansi_enabled = false;
+        t_ops.progress_enabled = false;
+        t_ops.colour_change = false;
+    }
+#endif //_WIN32
+
     try {
         Arguments args = parse_args(argc, argv);
         // If there is no command specified, just print help and quit.


### PR DESCRIPTION
## Description
Closes #63 
The issue was solved by selectively disabling text-based features. Details below in Design Notes.

## Design Notes
 - Non-Windows platforms are not affected by non-text based disabling (as they did not suffer from the issue).
 - The optional features are:
    - Whether to attempt to enable ANSI on required commands (Default = true)
    - Whether to show progress bars (Default = true)
    - Whether to use ANSI colour instead of Windows API colour (Default = false)
 - The text-based choices depend on the `TERM` variable.
 - If `TERM` is not set, the terminal will be tested for ANSI support. If no errors occur, default values are kept. Otherwise all options are made false.
 - If `TERM=xterm`, the terminal will be assumed only to have ANSI colour support, disabling other features.
 - If the `TERM` value is unknown, the options are all made false.
 - A new `get_env` method was added to consistently get environment variables across platforms.
 - If an ANSI exception occurs during the code, it will stop execution and print an error. However, this behavior should never occur, as ANSI is either checked at the start, or disabled.
 - All these options have been added to a new `terminal_options` struct. The only one to be concerned about is `progress_enabled`. This should be checked whenever a progress bar would be printed.
 - Metro sinks message was replaced in the case of disabled progress bars.