### PR TITLE
Fix #48

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -159,6 +159,10 @@ struct BranchNotFoundException : public MetroException {
     explicit BranchNotFoundException():
             MetroException("Branch not found.")
     {}
+
+    explicit BranchNotFoundException(const string& branch):
+            MetroException("Branch \"" + string(branch) + "\" not found.")
+    {}
 };
 
 /**

--- a/src/metro/metro.cpp
+++ b/src/metro/metro.cpp
@@ -158,6 +158,8 @@ namespace metro {
             }
         }
 
+        if (!branch_exists(repo, name)) throw BranchNotFoundException(name);
+
         Branch branch = repo.lookup_branch(name, GIT_BRANCH_LOCAL);
         branch.delete_branch();
         


### PR DESCRIPTION
## Description
Closes #48 
Check added to give error `Branch "branch-name" not found` in case of attempted deletion of a non-existent branch.