### PR TITLE
Add branches to commit listing

### DIFF
--- a/include/helper.h
+++ b/include/helper.h
@@ -187,3 +187,15 @@ void disable_ansi();
  * @return The contents of the variable
  */
 string get_env(const string& name);
+
+/**
+ * Replace all instances of a string with another
+ * string, returning the result.
+ *
+ * @param in Input string to replace in.
+ * @param find String to search for.
+ * @param replace String to replace with.
+ * @return The string with all instances of `find`
+ *         replaced with `replace`
+ */
+string replace_all(string in, string find, string replace);

--- a/src/commands/list.cpp
+++ b/src/commands/list.cpp
@@ -5,29 +5,59 @@
 /**
  * Prints the details of a given commit to the console.
  *
+ * @param repo The repo to search for branches in.
  * @param nth_parent The commit to print out.
  * @param hConsole The console to print using on Windows.
  */
-void print_details(git::Commit nth_parent, void *hConsole) {
+void print_details(const git::Repository &repo, git::Commit nth_parent, void *hConsole) {
     set_text_colour("rg------f", hConsole);
-    cout << "Commit " << nth_parent.id().str() << endl;
+    cout << "Commit " << nth_parent.id().str();
     set_text_colour("rgb-----r", hConsole);
+
+    // Print every branch that points to the current commit
+    git::BranchIterator it = repo.new_branch_iterator(GIT_BRANCH_LOCAL);
+    git::Branch b;
+    bool start = true;
+    while (it.next(&b)) {
+        string b_id((const char *) b.target().oid.id);
+        string c_id((const char *) nth_parent.id().oid.id);
+        if (c_id.compare(b_id) == 0) {
+            if (start) {
+                start = false;
+                cout << " (";
+            } else {
+                cout << ", ";
+            }
+            if (b.name() == metro::current_branch_name(repo)) {
+                // Green for current branch
+                set_text_colour("-g------f", hConsole);
+            } else {
+                // Orange for other branches
+                set_text_colour("-gb-----f", hConsole);
+            }
+            cout << b.name();
+            set_text_colour("rgb-----r", hConsole);
+        }
+    }
+    cout << (start ? "" : ")") << endl;
 
     git_signature author = nth_parent.author();
     cout << "Author: " << author.name << " (" << author.email << ")" << endl;
     cout << "Date: " << time_to_string(author.when) << endl;
-    cout << "\n    " << nth_parent.message() << endl;
+    cout << "\n    " << replace_all(nth_parent.message(), "\n", "\n    ") << endl;
 }
 
 /**
  * Prints the given commit followed by all parent commits with a prompt before each commit.
  *
+ * @param repo The repo to search for branches in.
  * @param commit Commit to begin printing from (Inclusive).
  * @param hConsole The console to print using on Windows.
+ * @return True if the user requested to exit. False if no more commits to print.
  */
-void print_from_commit(git::Commit commit, void *hConsole) {
+bool print_from_commit(const git::Repository &repo, git::Commit commit, void *hConsole) {
     unsigned int count = commit.parentcount();
-    print_details(commit, hConsole);
+    print_details(repo, commit, hConsole);
     cout << endl;
     for (unsigned int i = 0; i < count; i++) {
         git::Commit nth_parent = commit.parent(i);
@@ -39,12 +69,19 @@ void print_from_commit(git::Commit commit, void *hConsole) {
             cout << "\033[1A";
             clear_line();
             disable_ansi();
-            if (next == '\n') { print_from_commit(nth_parent, hConsole); break; }
-            else if (next == 'q') return;
+            if (next == '\n') {
+                // If user request exit, return from all
+                // Otherwise, backtrack to next parent
+                bool exit = print_from_commit(repo, nth_parent, hConsole);
+                if (exit) return true;
+                else break;
+            }
+            else if (next == 'q') return true;
         }
 
         if (i != count - 1) cout << endl;
     }
+    return false;
 }
 
 /**
@@ -74,7 +111,7 @@ Command listCmd{
                 }
 
                 git::Commit commit = metro::get_commit(repo, "HEAD");
-                print_from_commit(commit, hConsole);
+                print_from_commit(repo, commit, hConsole);
             } else if (args.positionals[0] == "branches") {
                 if (args.positionals.size() > 1) {
                     throw UnexpectedPositionalException(args.positionals[1]);
@@ -89,30 +126,32 @@ Command listCmd{
                         set_text_colour("-g------f", hConsole);
                         cout << branch.name() << endl;
                         set_text_colour("rgb-----r", hConsole);
+                        continue;
                     } else if (metro::is_wip(name)) {
                         continue;
                     } else if (name.find('#') != std::string::npos) {
                         cout << "   " << name.substr(0, name.find('#'));
                         set_text_colour("-gb-----f", hConsole);
-                        cout << "#" << name.substr(name.find('#') + 1) << endl;
+                        cout << "#" << name.substr(name.find('#') + 1);
                         set_text_colour("rgb-----r", hConsole);
                     } else {
-                        bool isWip = false;
-                        git::BranchIterator iter2 = repo.new_branch_iterator(GIT_BRANCH_LOCAL);
-                        for (git::Branch branch2; iter2.next(&branch2);) {
-                            if (branch2.name() == metro::to_wip(name)) {
-                                isWip = true;
-                                break;
-                            }
-                        }
                         cout << "   " << name;
-                        if (isWip) {
-                            set_text_colour("--bi----f", hConsole);
-                            cout << " (WIP)";
-                            set_text_colour("rgb-----r", hConsole);
-                        }
-                        cout << endl;
                     }
+
+                    bool isWip = false;
+                    git::BranchIterator iter2 = repo.new_branch_iterator(GIT_BRANCH_LOCAL);
+                    for (git::Branch branch2; iter2.next(&branch2);) {
+                        if (branch2.name() == metro::to_wip(name)) {
+                            isWip = true;
+                            break;
+                        }
+                    }
+                    if (isWip) {
+                        set_text_colour("--bi----f", hConsole);
+                        cout << " (WIP)";
+                        set_text_colour("rgb-----r", hConsole);
+                    }
+                    cout << endl;
                 }
             } else {
                 throw UnexpectedPositionalException(args.positionals[0]);

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -498,3 +498,14 @@ string get_env(const string& name) {
     return string(getenv(name.c_str()));
 #endif
 }
+
+string replace_all(string in, string find, string replace) {
+    if (find.empty()) return in;
+
+    size_t start = in.find(find, 0);
+    while (start != string::npos) {
+        in.replace(start, find.length(), replace);
+        start = in.find(find, start + replace.length());
+    }
+    return in;
+}


### PR DESCRIPTION
## Description
Closes #23 
Adds branch labels to commit listings.

## Changes
 - Adds branch labels for local branches to commit listings
 - Fixes bug in user input
 - Fixes bug in multi-line commit messages
 - Fixes bug where WIP is not shown in branch listing after '#'
 - The current branch has a different colour in the commit listing
 - Adds a new `replace_all` function, replacing all instances of a string with another in the target string