### PR TITLE
Add Command Suggestions for Common Git Commands

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -21,3 +21,27 @@ Command *allCommands[] = {
         &listCmd,
         &sinkCmd
 };
+
+// Defines a mistype the user may make
+struct Mistype {
+    string input;       // The string the user inputs
+    string message;     // The message to print if that string is detected
+};
+
+// Mistypes are checked before commands.
+// If the mistype is the same a command,
+// the command will become impossible to run.
+const Mistype ALL_MISTYPES[] = {
+        {"commit -m", "Metro doesn't require the -m option for a commit message.\nDid you mean metro commit <message>?"},
+        {"add", "Metro automatically adds the working directory to the staging area."},
+        {"push", "Did you mean metro sync --push?"},
+        {"pull", "Did you mean metro sync --pull?"},
+        {"merge", "Did you mean metro absorb <branch>?"},
+        {"checkout", "Did you mean metro switch <branch>?"},
+        {"log", "Did you mean metro list commits?"},
+        {"init", "Did you mean metro create?"},
+        {"rm", "Metro automatically adds the working directory to the staging area.\nTo exclude files from sync you must use a .gitignore"},
+        {"status", "Did you mean metro info?"},
+        {"rebase", "Metro currently has no support for rebasing."},
+        {"reset", "Metro currently has no support for resetting."}
+};

--- a/include/main.h
+++ b/include/main.h
@@ -33,14 +33,14 @@ struct Mistype {
 // the command will become impossible to run.
 const Mistype ALL_MISTYPES[] = {
         {"commit -m", "Metro doesn't require the -m option for a commit message.\nDid you mean metro commit <message>?"},
-        {"add", "Metro automatically adds the working directory to the staging area."},
+        {"add", "Metro automatically adds all files in the repository to the staging area."},
         {"push", "Did you mean metro sync --push?"},
         {"pull", "Did you mean metro sync --pull?"},
         {"merge", "Did you mean metro absorb <branch>?"},
         {"checkout", "Did you mean metro switch <branch>?"},
         {"log", "Did you mean metro list commits?"},
         {"init", "Did you mean metro create?"},
-        {"rm", "Metro automatically adds the working directory to the staging area.\nTo exclude files from sync you must use a .gitignore"},
+        {"rm", "Metro automatically adds all files in the repository to the staging area.\nTo exclude files from a commit use git commit."},
         {"status", "Did you mean metro info?"},
         {"rebase", "Metro currently has no support for rebasing."},
         {"reset", "Metro currently has no support for resetting."}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,6 +139,29 @@ void printHelp() {
     cout << "Use --help for help.\n";
 }
 
+/**
+ * Checks the input for any matches in ALL_MISTYPES (main.h)
+ * at the start of the arguments. If a match is found, the message
+ * will be printed and return true.
+ *
+ * @param argc Number of arguments.
+ * @param argv The arguments to parse.
+ * @return True if a match was found.
+ */
+bool mistype_check(int argc, char *argv[]) {
+    stringstream s;
+    for (int i = 1; i < argc; i++) {
+        s << argv[i] << " ";
+    }
+    string input = s.str();
+    for (Mistype m : ALL_MISTYPES) {
+        if (input.find(m.input) == 0) {
+            cout << m.message << endl;
+            return true;
+        }
+    }
+    return false;
+}
 
 /**
  * Entry point of the program, passing off parsing to above functions
@@ -181,6 +204,8 @@ int main(int argc, char *argv[]) {
         t_ops.ansi_colour_change = false;
     }
 #endif //_WIN32
+
+    if (mistype_check(argc, argv)) return -1;
 
     try {
         Arguments args = parse_args(argc, argv);


### PR DESCRIPTION
## Description
Closes #31 
Adds command suggestions for common git commands

## Changes
 - Mistype struct for mistypes and message to show if found
 - ALL_MISTYPES contains all mistypes searched for
 - Mistypes are searched before any commands
 - When a mistype is found, a message is printed