### PR TITLE
Prevent patch with invalid creds without force

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -30,7 +30,7 @@ struct Command {
 // List of all valid options
 // Keep them in alphabetical order (by name) to make help messages easier to read
 const Option ALL_OPTIONS[] = {
-        {"force", "f", false, "Not yet implemented"},
+        {"force", "f", false, "Forces execution of the command ignoring warnings"}, // Current applies onto to metro patch
         {"help", "h", false, "Explain how to use command"},
         {"pull", "d", false, "Only pull changes, without pushing changes to remote"},
         {"push", "u", false, "Only push changes, without pulling changes from remote. Requires no conflicts"},

--- a/include/commands.h
+++ b/include/commands.h
@@ -30,7 +30,7 @@ struct Command {
 // List of all valid options
 // Keep them in alphabetical order (by name) to make help messages easier to read
 const Option ALL_OPTIONS[] = {
-        {"force", "f", false, "Forces execution of the command ignoring warnings"}, // Current applies onto to metro patch
+        {"force", "f", false, "Forces execution of the command ignoring warnings"},
         {"help", "h", false, "Explain how to use command"},
         {"pull", "d", false, "Only pull changes, without pushing changes to remote"},
         {"push", "u", false, "Only push changes, without pulling changes from remote. Requires no conflicts"},

--- a/src/commands/patch.cpp
+++ b/src/commands/patch.cpp
@@ -25,6 +25,20 @@ Command patch {
                 throw UnexpectedPositionalException(args.positionals[1]);
             }
 
+            // Check owner if force not passed
+            if (args.options.find("force") == args.options.end()) {
+                string commit_auth((const char *) commit.author().name);
+                string current_auth((const char *) repo.default_signature().name);
+                string commit_auth_e((const char *) commit.author().email);
+                string current_auth_e((const char *) repo.default_signature().email);
+                if (commit_auth != current_auth && commit_auth_e != current_auth_e) {
+                    cout << "Your credentials are different to the author of the commit you are trying to patch." << endl;
+                    cout << "Patching the commit will override their credentials with your own." << endl;
+                    cout << "If you would still like to patch, use metro patch --force." << endl;
+                    return;
+                }
+            }
+
             metro::patch(repo, message);
             cout << "Patched commit.\n";
         },


### PR DESCRIPTION
## Description
Closes #43 
Compares current credentials to last commits before patching
If both the username and the email are different, a warning will be raised
This can be overridden by `metro patch --force`