### PR TITLE
Add -v option

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -30,11 +30,11 @@ struct Command {
 // List of all valid options
 // Keep them in alphabetical order (by name) to make help messages easier to read
 const Option ALL_OPTIONS[] = {
-        {"force", "f", false, "Forces execution of the command ignoring warnings"},
+        {"force", "f", false, "Force execution of command ignoring warnings"},
         {"help", "h", false, "Explain how to use command"},
         {"pull", "d", false, "Only pull changes, without pushing changes to remote"},
         {"push", "u", false, "Only push changes, without pulling changes from remote. Requires no conflicts"},
         {"soft", "s", false, "Delete the last commit without reverting changes in the working directory"},
-        {"version", "v", false, "Finds the version of Metro being used"}
+        {"version", "v", false, "Print the version of Metro being used"}
 };
 

--- a/include/commands.h
+++ b/include/commands.h
@@ -34,6 +34,7 @@ const Option ALL_OPTIONS[] = {
         {"help", "h", false, "Explain how to use command"},
         {"pull", "d", false, "Only pull changes, without pushing changes to remote"},
         {"push", "u", false, "Only push changes, without pulling changes from remote. Requires no conflicts"},
-        {"soft", "s", false, "Delete the last commit without reverting changes in the working directory"}
+        {"soft", "s", false, "Delete the last commit without reverting changes in the working directory"},
+        {"version", "v", false, "Finds the version of Metro being used"}
 };
 

--- a/include/main.h
+++ b/include/main.h
@@ -5,6 +5,11 @@
 #pragma once
 #include "pch.h"
 
+#define METRO_RELEASE "alpha-debug"
+#define METRO_MAJOR 1
+#define METRO_MINOR 0
+#define METRO_REVISION 0
+
 // List of all commands
 Command *allCommands[] = {
         &create,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,6 +137,7 @@ void printHelp() {
         cout << cmd->name << " - " << cmd->description << "\n";
     }
     cout << "Use --help for help.\n";
+    cout << "Use --version to print Metro version.\n";
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -209,6 +209,13 @@ int main(int argc, char *argv[]) {
 
     try {
         Arguments args = parse_args(argc, argv);
+
+        // If -v is specified, ignore all other contents of the command, printing version and exiting.
+        if (args.options.find("version") != args.options.end()) {
+            cout << "Metro version " << METRO_RELEASE << "-" << METRO_MAJOR << "." << METRO_MINOR << "." << METRO_REVISION << endl;
+            return 0;
+        }
+
         // If there is no command specified, just print help and quit.
         if (args.positionals.empty()) {
             printHelp();


### PR DESCRIPTION
## Description
Closes #74 
Adds a version option to metro allowing one to find what version is being run.