### PR TITLE
Implement Rename Command

### DIFF
--- a/include/gitwrapper/branch.h
+++ b/include/gitwrapper/branch.h
@@ -86,5 +86,17 @@ namespace git {
          * Delete an existing branch.
          */
         void delete_branch() const;
+
+        /**
+         * Move/rename an existing local branch reference.
+         *
+         * The new branch name will be checked for validity.
+         * See `git_tag_create()` for rules about valid names.
+         *
+         * @param new_branch_name Target name of the branch once the move
+         * is performed; this name is validated for consistency.
+         * @param force True to overwrite existing branch.
+         */
+        void rename(string new_branch_name, bool force);
     };
 }

--- a/include/main.h
+++ b/include/main.h
@@ -19,7 +19,8 @@ Command *allCommands[] = {
         &resolve,
         &syncCmd,
         &listCmd,
-        &sinkCmd
+        &sinkCmd,
+        &renameCmd
 };
 
 // Defines a mistype the user may make

--- a/src/commands/rename.cpp
+++ b/src/commands/rename.cpp
@@ -1,0 +1,62 @@
+/*
+ * Defines the Rename command.
+ */
+
+/**
+ * The rename command is used to rename a branch.
+ */
+Command renameCmd {
+        "rename",
+        "Rename a branch",
+
+        // execute
+        [](const Arguments &args) {
+            if (args.positionals.empty()) {
+                throw MissingPositionalException("branch-1");
+            }
+            if (args.positionals.size() > 2) {
+                throw UnexpectedPositionalException(args.positionals[2]);
+            }
+
+            git::Repository repo = git::Repository::open(".");
+
+            string from, to;
+            if (args.positionals.size() == 1) {
+                to = args.positionals[0];
+                try {
+                    from = metro::current_branch_name(repo);
+                } catch (BranchNotFoundException &e) {
+                    throw MetroException("The HEAD is not pointing at any branch, so cannot rename.\nTry using 'metro rename <branch> " + to + "'.");
+                }
+            } else {
+                from = args.positionals[0];
+                to = args.positionals[1];
+            }
+
+            bool force = args.options.find("force") != args.options.end();
+
+            // Ensure target branch + wip doesn't exist
+            if (metro::branch_exists(repo, to) && !force) throw MetroException("There is already a branch with that name.\nTo override it, use 'metro rename --force'.");
+            if (metro::branch_exists(repo, metro::to_wip(to)) && !force) throw MetroException("There is a wip for the target branch name.\nTo override it, use 'metro rename --force'.");
+
+            git::Branch current = repo.lookup_branch(from, GIT_BRANCH_LOCAL);
+            current.rename(to, force);
+
+            // Delete target wip if exists
+            if (metro::branch_exists(repo, metro::to_wip(to))) {
+                metro::delete_branch(repo, metro::to_wip(to));
+            }
+
+            // Move wip to target wip
+            if (metro::branch_exists(repo, metro::to_wip(from))) {
+                git::Branch wip = repo.lookup_branch(metro::to_wip(from), GIT_BRANCH_LOCAL);
+                wip.rename(metro::to_wip(to), force);
+            }
+            cout << "Renamed branch " << from << " to " << to << "." << endl;
+        },
+
+        // printHelp
+        [](const Arguments &args) {
+            cout << "Usage: metro rename <branch-1> <branch-2>" << endl;
+        }
+};

--- a/src/commands/rename.cpp
+++ b/src/commands/rename.cpp
@@ -36,8 +36,8 @@ Command renameCmd {
             bool force = args.options.find("force") != args.options.end();
 
             // Ensure target branch + wip doesn't exist
-            if (metro::branch_exists(repo, to) && !force) throw MetroException("There is already a branch with that name.\nTo override it, use 'metro rename --force'.");
-            if (metro::branch_exists(repo, metro::to_wip(to)) && !force) throw MetroException("There is a wip for the target branch name.\nTo override it, use 'metro rename --force'.");
+            if (metro::branch_exists(repo, to) && !force) throw UnsupportedOperationException("There is already a branch with that name.\nTo overwrite it, use 'metro rename --force'.");
+            if (metro::branch_exists(repo, metro::to_wip(to)) && !force) throw UnsupportedOperationException("There is a WIP branch for the target branch name.\nTo overwrite it, use 'metro rename --force'.");
 
             git::Branch current = repo.lookup_branch(from, GIT_BRANCH_LOCAL);
             current.rename(to, force);

--- a/src/gitwrapper/branch.cpp
+++ b/src/gitwrapper/branch.cpp
@@ -49,6 +49,6 @@ namespace git {
         git_reference *branch = ref.get();
         int err = git_branch_move(&out, branch, new_branch_name.c_str(), force_i);
         check_error(err);
-        ref.reset(out);
+        ref.reset(out, git_reference_free);
     }
 }

--- a/src/gitwrapper/branch.cpp
+++ b/src/gitwrapper/branch.cpp
@@ -42,4 +42,13 @@ namespace git {
     void Branch::delete_reference() const {
         git_reference_delete(ref.get());
     }
+
+    void Branch::rename(string new_branch_name, bool force) {
+        int force_i = (int) force;
+        git_reference *out;
+        git_reference *branch = ref.get();
+        int err = git_branch_move(&out, branch, new_branch_name.c_str(), force_i);
+        check_error(err);
+        ref.reset(out);
+    }
 }

--- a/src/pch.cpp
+++ b/src/pch.cpp
@@ -36,3 +36,4 @@
 #include "commands/sync.cpp"
 #include "commands/list.cpp"
 #include "commands/sink.cpp"
+#include "commands/rename.cpp"


### PR DESCRIPTION
## Description
Closes #25 
Creates the `metro rename` command
Use of the command with one parameter will rename the current branch
Otherwise, the first parameter branch is renamed to the second parameter
The rename will only take place if the target does not exist
If it does, renaming can still be done by using force
This will completely override the target branch
All operations will also be applied to WIP branches, including moving and deleting them