### PR TITLE
Add additional tests

### DIFF
--- a/src/commands/rename.cpp
+++ b/src/commands/rename.cpp
@@ -57,6 +57,6 @@ Command renameCmd {
 
         // printHelp
         [](const Arguments &args) {
-            cout << "Usage: metro rename <branch-1> <branch-2>" << endl;
+            cout << "Usage: metro rename <branch-1> [<branch-2>]" << endl;
         }
 };

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -1325,6 +1325,45 @@ setup() {
   [[ "${lines[12]}" == *"Test Commit 1"* ]]
 }
 
+@test "Absorb branch with content conflict and switch before resolve" {
+  echo "Mark 1"
+  git init
+  git commit --allow-empty -m "Initial Commit"
+  git branch separate
+
+  echo "Mark 2"
+  git checkout -b other
+  echo "Test file content 1" > test.txt
+  git add -A
+  git commit -m "Test Commit 1"
+
+  echo "Mark 3"
+  git checkout master
+  echo "Test file content 2" > test.txt
+  git add -A
+  git commit -m "Test Commit 2"
+
+  echo "Mark 4"
+  metro absorb other
+
+  echo "Mark 5"
+  git log
+  run git log
+  [[ "${lines[3]}" == *"Test Commit 2"* ]]
+
+  echo "Mark 6"
+  metro switch separate
+  metro switch master
+  metro resolve
+
+  echo "Mark 7"
+  git log
+  run git log
+  [[ "${lines[4]}" == *"Absorbed other"* ]]
+  [[ "${lines[8]}" == *"Test Commit 2"* ]]
+  [[ "${lines[12]}" == *"Test Commit 1"* ]]
+}
+
 @test "Absorb branch while detached" {
   echo "Mark 1"
   git init


### PR DESCRIPTION
Includes additional tests for `absorb`, `resolve`, `list` and `rename`
Improved `rename` help
Removed redundancy from tests setup
Fixes bug in "Info with no commits" test